### PR TITLE
Latest release of GoogleTest for modern Cmake

### DIFF
--- a/AddGoogleTest.cmake
+++ b/AddGoogleTest.cmake
@@ -24,8 +24,7 @@ if(CMAKE_VERSION VERSION_LESS 3.11)
 else()
     include(FetchContent)
     FetchContent_Declare(googletest
-        GIT_REPOSITORY      https://github.com/google/googletest.git
-        GIT_TAG             release-1.8.0)
+        GIT_REPOSITORY      https://github.com/google/googletest.git)
     FetchContent_GetProperties(googletest)
     if(NOT googletest_POPULATED)
         FetchContent_Populate(googletest)


### PR DESCRIPTION
Using release 1.8.0 produces an annoying amount of deprecation warnings  at the moment for current versions of CMake.